### PR TITLE
修复文字处理越界bug，增加对老版本python的支持

### DIFF
--- a/gsv_tts/GPT_SoVITS/Featurizer/cnroberta.py
+++ b/gsv_tts/GPT_SoVITS/Featurizer/cnroberta.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 from ...config import Config
 from transformers import AutoModelForMaskedLM, AutoTokenizer
-
+from typing import List
 
 class CNRoberta(nn.Module):
     def __init__(self, base_path, tts_config: Config):
@@ -14,7 +14,7 @@ class CNRoberta(nn.Module):
         if tts_config.is_half: 
             self.bert_model = self.bert_model.half()
     
-    def forward(self, texts: list[str], word2ph_list: list[list[int]]):
+    def forward(self, texts: List[str], word2ph_list: List[List[int]]):
         with torch.no_grad():
             sep = self.tokenizer.sep_token
             combined_text = sep.join(texts)

--- a/gsv_tts/GPT_SoVITS/G2P/Chinese/chinese.py
+++ b/gsv_tts/GPT_SoVITS/G2P/Chinese/chinese.py
@@ -2,6 +2,7 @@ import re
 
 import cn2an
 from pypinyin import lazy_pinyin, Style
+from typing import List
 
 from ..Symbols import punctuation
 from .tone_sandhi import ToneSandhi
@@ -115,7 +116,7 @@ class ChineseG2P:
             finals.append(v)
         return initials, finals
 
-    def _merge_erhua(self, initials: list[str], finals: list[str], word: str, pos: str) -> list[list[str]]:
+    def _merge_erhua(self, initials: List[str], finals: List[str], word: str, pos: str) -> List[List[str]]:
         """
         Do erhub.
         """

--- a/gsv_tts/TTS.py
+++ b/gsv_tts/TTS.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import gc
 import os
 

--- a/gsv_tts/TextProcessor.py
+++ b/gsv_tts/TextProcessor.py
@@ -71,7 +71,7 @@ def segment_language_text(text):
                     tokens[i]['lang'] = 'ja'
                     break
             
-            for j in range(i+1, end+1):
+            for j in range(i+1, end):
                 if tokens[j]['lang'] == 'punc':
                     break
                 if tokens[j]['lang'] == 'ja':


### PR DESCRIPTION
目前使用3.8及以前版本的python时，会因为原生的 list 无法接受 list[str] 这样的下标泛型提示而提示错误。

同时，gsv_tts/TextProcessor.py中，当数据使前瞻窗口刚好处在列表的末尾会导致数组越界。