### PR TITLE
fix type of spk_audio_paths

### DIFF
--- a/gsv_tts/TTS.py
+++ b/gsv_tts/TTS.py
@@ -512,7 +512,7 @@ class TTS:
 
             logging.info(f"Starting batched TTS inference: processing {n} text segments.")
 
-            if isinstance(spk_audio_paths, str):
+            if isinstance(spk_audio_paths, (str,dict)):
                 spk_audio_paths = [spk_audio_paths]*n
             if isinstance(prompt_audio_paths, str):
                 prompt_audio_paths = [prompt_audio_paths]*n


### PR DESCRIPTION
* 修复：batch infer使用字典混合音色参考时，缺少对单一参考类型为dict判断导致`expand_input`报错