### PR TITLE
feat: auto-generate GPT KV cache buckets for adaptive text length

### DIFF
--- a/API/fastapi_server_example.py
+++ b/API/fastapi_server_example.py
@@ -112,9 +112,19 @@ class TTSBatchRequest(BaseModel):
 async def startup_event():
     global tts, asr
     print("🚀 正在加载 TTS 模型...")
+    
+    max_cache_len = 1024
+    batch_sizes = [1, 4, 8]
+    cache_lens = []
+    length = 512
+    while length <= max_cache_len:
+        cache_lens.append(length)
+        length *= 2
+    gpt_cache = [(b, c) for b in batch_sizes for c in cache_lens]
+    
     tts = TTS(
         models_dir=str(models_dir),
-        gpt_cache=[(1, 512), (4, 512), (8, 512)],
+        gpt_cache=gpt_cache,
         sovits_cache=[50],
     )
     print("✅ TTS 模型加载完成！")

--- a/API/personal_api.py
+++ b/API/personal_api.py
@@ -149,9 +149,19 @@ class TTSBatchedRequest(BaseModel):
 async def startup_event():
     global tts, asr
     print("正在加载 TTS 模型...")
+    
+    max_cache_len = 1024
+    batch_sizes = [1, 4, 8]
+    cache_lens = []
+    length = 512
+    while length <= max_cache_len:
+        cache_lens.append(length)
+        length *= 2
+    gpt_cache = [(b, c) for b in batch_sizes for c in cache_lens]
+    
     tts = TTS(
         models_dir=str(models_dir),
-        gpt_cache=[(1, 512), (4, 512), (8, 512)],
+        gpt_cache=gpt_cache,
         sovits_cache=[50],
     )
     print("TTS 模型加载完成！")

--- a/API/test_async_performance.py
+++ b/API/test_async_performance.py
@@ -15,9 +15,18 @@ async def main():
     
     models_dir = base_dir / "WebUI" / "models"
     
+    max_cache_len = 1024
+    batch_sizes = [1, 4, 8]
+    cache_lens = []
+    length = 512
+    while length <= max_cache_len:
+        cache_lens.append(length)
+        length *= 2
+    gpt_cache = [(b, c) for b in batch_sizes for c in cache_lens]
+    
     tts = TTS(
         models_dir=str(models_dir),
-        gpt_cache=[(1, 512), (4, 512), (8, 512)],
+        gpt_cache=gpt_cache,
         sovits_cache=[50],
     )
     

--- a/WebUI/web.py
+++ b/WebUI/web.py
@@ -512,7 +512,7 @@ if __name__ == "__main__":
             return False
         
     parser = argparse.ArgumentParser(description="GSV-TTS")
-    parser.add_argument("--gpt_cache_len", type=int, default=512, help="GPT KV cache 上下文长度")
+    parser.add_argument("--gpt_cache_len", type=int, default=1024, help="GPT KV cache 上下文长度")
     parser.add_argument("--gpt_batch_size", type=int, default=8, help="GPT 最大并行推理大小")
     parser.add_argument("--use_bert", type=str2bool, default=True, help="使用BERT提升中文语义理解能力")
     parser.add_argument("--use_flash_attn", type=str2bool, default=False, help="使用Flash Attn加速推理")
@@ -571,8 +571,17 @@ if __name__ == "__main__":
 
 
 
+    batch_sizes = [1] + list(range(4, args.gpt_batch_size, 4)) + [args.gpt_batch_size]
+    cache_lens = []
+    length = 512
+    while length <= args.gpt_cache_len:
+        cache_lens.append(length)
+        length *= 2
+    
+    gpt_cache = [(b, c) for b in batch_sizes for c in cache_lens]
+
     tts = TTS(
-        gpt_cache=[(1, args.gpt_cache_len)] + [(B, args.gpt_cache_len) for B in range(4, args.gpt_batch_size-1, 4)] + [(args.gpt_batch_size, args.gpt_cache_len)],
+        gpt_cache=gpt_cache,
         sovits_cache=[],
         use_bert=args.use_bert,
         use_flash_attn=args.use_flash_attn,


### PR DESCRIPTION
优化 GPT KV Cache 配置，支持自动分档切换

问题：
- 原有配置固定使用单一 cache 长度（512），当生成长文本时会导致截断吞字
- 用户需要手动调整参数才能支持长文本

改进：
- 将默认 cache 长度从 512 提升到 1024
- 实现自动分档机制：根据 max_cache_len 自动生成 512/1024/2048 等档位
- 短文本自动使用小 cache（节省显存），长文本自动切换大 cache（避免截断）

修改文件：
- WebUI/web.py: 增加 cache 分档逻辑，支持命令行参数配置
- API/personal_api.py: 应用相同的分档逻辑
- API/fastapi_server_example.py: 应用相同的分档逻辑
- API/test_async_performance.py: 应用相同的分档逻辑